### PR TITLE
Patch current version instead of bundled version.

### DIFF
--- a/www/IonicCordova.ts
+++ b/www/IonicCordova.ts
@@ -11,6 +11,13 @@ declare global {
 export interface DeployPluginAPI {
 
   /**
+   * @description Call this function after your app has finished configuring appflow.
+   *
+   * Added by propel.
+   */
+  onLoad(): Promise<void>;
+
+  /**
    * @description Update the default configuration for the plugin on the current device. The new configuration will be persisted across app close and binary updates.
    *
    * @since v5.0.0

--- a/www/common.ts
+++ b/www/common.ts
@@ -132,21 +132,6 @@ class IonicDeployImpl {
     return folder;
   }
 
-  getCurrentAppDir(): { path: string, directory: string } {
-    const prefs = this._savedPreferences;
-    if (prefs.currentVersionId && this._isRunningVersion(prefs.currentVersionId)) {
-      return {
-        path:  Path.join(this.SNAPSHOT_CACHE, prefs.currentVersionId),
-        directory: 'DATA',
-      }
-    }
-
-    return {
-      path: this.getBundledAppDir(),
-      directory: 'APPLICATION',
-    }
-  }
-
   private async _savePrefs(prefs: ISavedPreferences): Promise<ISavedPreferences> {
     return new Promise<ISavedPreferences>(async (resolve, reject) => {
       try {
@@ -468,7 +453,7 @@ class IonicDeployImpl {
 
   private async _copyCurrentAppDir(versionId: string) {
     const timer = new Timer('CopyCurrentApp');
-    const source = this.getCurrentAppDir();
+    const source = { path: this.getBundledAppDir(), directory: 'APPLICATION' };
     const target = this.getSnapshotCacheDir(versionId);
     console.log('Copying current app', source, target);
     await this._fileManager.copyTo({ source, target });

--- a/www/common.ts
+++ b/www/common.ts
@@ -132,12 +132,19 @@ class IonicDeployImpl {
     return folder;
   }
 
-  getCurrentAppDir(): string {
+  getCurrentAppDir(): { path: string, directory: string } {
     const prefs = this._savedPreferences;
     if (prefs.currentVersionId && this._isRunningVersion(prefs.currentVersionId)) {
-      return this.getSnapshotCacheDir(prefs.currentVersionId)
+      return {
+        path:  Path.join(this.SNAPSHOT_CACHE, prefs.currentVersionId),
+        directory: 'DATA',
+      }
     }
-    return this.getBundledAppDir();
+
+    return {
+      path: this.getBundledAppDir(),
+      directory: 'APPLICATION',
+    }
   }
 
   private async _savePrefs(prefs: ISavedPreferences): Promise<ISavedPreferences> {
@@ -204,7 +211,11 @@ class IonicDeployImpl {
 
     let jsonResp;
     if (resp.status < 500) {
-      jsonResp = await resp.json();
+      try {
+        jsonResp = await resp.json();
+      } catch (error) {
+        console.error('Error in appflow response', error);
+      }
     }
     if (resp.ok) {
       const checkForUpdateResp: CheckForUpdateResponse = jsonResp.data;
@@ -236,6 +247,8 @@ class IonicDeployImpl {
         await this.preparePartialUpdateDirectory(prefs.availableUpdate.versionId, removals);
         await this._downloadFilesFromManifest(fileBaseUrl, additions,  prefs.availableUpdate.versionId, progress);
       } catch (e) {
+        console.info('Error downloading a partial update. Downloading full update instead.');
+        console.error(e);
         await this.prepareEmptyUpdateDirectory(prefs.availableUpdate.versionId);
         await this._downloadFilesFromManifest(fileBaseUrl, manifestJson,  prefs.availableUpdate.versionId, progress);
       }
@@ -455,13 +468,10 @@ class IonicDeployImpl {
 
   private async _copyCurrentAppDir(versionId: string) {
     const timer = new Timer('CopyCurrentApp');
-    await this._fileManager.copyTo({
-      source: {
-        path: this.getCurrentAppDir(),
-        directory: 'APPLICATION',
-      },
-      target: this.getSnapshotCacheDir(versionId),
-    });
+    const source = this.getCurrentAppDir();
+    const target = this.getSnapshotCacheDir(versionId);
+    console.log('Copying current app', source, target);
+    await this._fileManager.copyTo({ source, target });
     timer.end();
   }
 
@@ -613,7 +623,7 @@ class IonicDeploy implements IDeployPluginAPI {
     this.parent = parent;
     this.delegate = this.initialize();
     this.fetchIsAvailable = typeof(fetch) === 'function';
-    document.addEventListener('deviceready', this.onLoad.bind(this));
+    // document.addEventListener('deviceready', this.onLoad.bind(this));
   }
 
   async initialize() {

--- a/www/index.ts
+++ b/www/index.ts
@@ -20,6 +20,11 @@ const deviceready = new Promise<IDeployPluginAPI>((resolve, rejects) => {
 
 export class DeployClass implements IDeployPluginAPI {
 
+  async onLoad() {
+    const deploy = await deviceready;
+    return deploy.onLoad();
+  }
+
   async configure(config: IDeployConfig) {
     const deploy = await deviceready;
     return deploy.configure(config);


### PR DESCRIPTION
After merging this PR, the application is responsible for invoke onLoad directly. But it can also configure things as a result. Tested against this PR -> https://github.com/propelinc/freshebt-vue/pull/1139/files